### PR TITLE
Fix minor problems.

### DIFF
--- a/aequitas.gemspec
+++ b/aequitas.gemspec
@@ -164,4 +164,6 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_development_dependency("minitest", ["~> 2.8"])
+  s.add_development_dependency("virtus",   ["~> 0.2.0"])
+  s.add_development_dependency("dm-core",  ["~> 1.3.0"])
 end

--- a/lib/aequitas/message_transformer.rb
+++ b/lib/aequitas/message_transformer.rb
@@ -113,9 +113,7 @@ module Aequitas
         raise ArgumentError, "+violation+ must be specified" if violation.nil?
 
         resource       = violation.resource
-        # TODO: resource#model and Model#model_name are assumptions from DM
-        #   Figure out a more flexible way to lookup error messages in I18n
-        model_name     = resource.model.model_name
+        model_name     = resource.class.name
         attribute_name = violation.attribute_name
         # TODO: Include attribute value in Violation; it may have changed by now
         # attribute_value = violation.attribute_value

--- a/lib/aequitas/rule/numericalness.rb
+++ b/lib/aequitas/rule/numericalness.rb
@@ -50,6 +50,7 @@ module Aequitas
         # Avoid Scientific Notation in Float to_s
         when Float      then value.to_d.to_s('F')
         when BigDecimal then value.to_s('F')
+        when Rational   then value_as_string(value.to_f)
         else value.to_s
         end
       end

--- a/lib/aequitas/rule/primitive_type/virtus.rb
+++ b/lib/aequitas/rule/primitive_type/virtus.rb
@@ -12,7 +12,9 @@ module Aequitas
         def initialize(attribute_name, options = {})
           @attribute = options.fetch(:attribute)
 
-          super(attribute_name, :primitive => attribute.class.primitive)
+          options[:primitive] ||= attribute.class.primitive
+
+          super(attribute_name, options)
         end
 
         def expected_type?(value)


### PR DESCRIPTION
Sorry for not splitting the changes into separate pull requests, but I was to lazy for this one liners.

The only discussion pint I see is the use of Rational, since Rational might not be required by default? 

Changes:
- Add Rational to numericallness validator
- Make sure options are not truncated for PrimitiveType::Virtus
- Use object.class.name instead of object.model.name for default MessageTransformer
- Add an explict virtus development dependency.
  
  It breaks no specs. So no specs are changed. Virtus primitive validator clearly needs more specs.
